### PR TITLE
feat: add knowledge base datasource manage API

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -18,4 +18,4 @@ run_dev_server:
 
 run_dev_celery_worker:
 	@echo "Running celery..."
-	@rye run celery -A app.celery worker --pool solo --concurrency=1 --loglevel=DEBUG
+	@rye run celery -A app.celery worker

--- a/backend/app/api/admin_routes/data_source.py
+++ b/backend/app/api/admin_routes/data_source.py
@@ -34,7 +34,7 @@ class DataSourceCreate(BaseModel):
         return v
 
 
-@router.post("/admin/datasources")
+@router.post("/admin/datasources", deprecated=True)
 def create_datasource(
     session: SessionDep, user: CurrentSuperuserDep, request: DataSourceCreate
 ) -> DataSource:
@@ -52,7 +52,7 @@ def create_datasource(
     return data_source
 
 
-@router.get("/admin/datasources")
+@router.get("/admin/datasources", deprecated=True)
 def list_datasources(
     session: SessionDep,
     user: CurrentSuperuserDep,
@@ -61,22 +61,7 @@ def list_datasources(
     return data_source_repo.paginate(session, params)
 
 
-@router.get("/admin/datasources/{data_source_id}")
-def get_datasource(
-    session: SessionDep,
-    user: CurrentSuperuserDep,
-    data_source_id: int,
-) -> DataSource:
-    data_source = data_source_repo.get(session, data_source_id)
-    if data_source is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Data source not found",
-        )
-    return data_source
-
-
-@router.delete("/admin/datasources/{data_source_id}")
+@router.delete("/admin/datasources/{data_source_id}", deprecated=True)
 def delete_datasource(
     session: SessionDep,
     user: CurrentSuperuserDep,
@@ -142,10 +127,10 @@ def retry_failed_tasks(
     data_source = data_source_repo.get(session, data_source_id)
     if data_source is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-    for docuemnt_id in data_source_repo.set_failed_vector_index_tasks_to_pending(
+    for document_id in data_source_repo.set_failed_vector_index_tasks_to_pending(
         session, data_source
     ):
-        build_vector_index_from_document.delay(data_source_id, docuemnt_id)
+        build_vector_index_from_document.delay(data_source_id, document_id)
     for chunk_id, document_id in data_source_repo.set_failed_kg_index_tasks_to_pending(
         session, data_source
     ):

--- a/backend/app/api/admin_routes/data_source.py
+++ b/backend/app/api/admin_routes/data_source.py
@@ -61,6 +61,20 @@ def list_datasources(
     return data_source_repo.paginate(session, params)
 
 
+@router.get("/admin/datasources/{data_source_id}", deprecated=True)
+def get_datasource(
+        session: SessionDep,
+        user: CurrentSuperuserDep,
+        data_source_id: int,
+) -> DataSource:
+    data_source = data_source_repo.get(session, data_source_id)
+    if data_source is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Data source not found",
+        )
+    return data_source
+
 @router.delete("/admin/datasources/{data_source_id}", deprecated=True)
 def delete_datasource(
     session: SessionDep,

--- a/backend/app/api/admin_routes/embedding_model/models.py
+++ b/backend/app/api/admin_routes/embedding_model/models.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing_extensions import Optional
 
 from app.models.embed_model import DEFAULT_VECTOR_DIMENSION
@@ -11,10 +11,16 @@ class EmbeddingModelCreate(BaseModel):
     name: str
     provider: EmbeddingProvider
     model: str
-    vector_dimension: int = DEFAULT_VECTOR_DIMENSION
+    vector_dimension: int
     config: dict | list | None
     credentials: Any
     is_default: Optional[bool] = False
+
+    @field_validator("vector_dimension")
+    def name_must_not_be_blank(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("The vector dimension of the Embedding model should be at least greater than 1.")
+        return v
 
 
 class EmbeddingModelUpdate(BaseModel):

--- a/backend/app/api/admin_routes/embedding_model/routes.py
+++ b/backend/app/api/admin_routes/embedding_model/routes.py
@@ -14,7 +14,7 @@ from app.api.deps import CurrentSuperuserDep, SessionDep
 from app.exceptions import EmbeddingModelNotFoundError, InternalServerError
 from app.rag.chat_config import get_embedding_model
 from app.rag.embed_model_option import EmbeddingModelOption, admin_embed_model_options
-from app.repositories.embedding_model import embedding_model_repo
+from app.repositories.embedding_model import embed_model_repo
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ def create_embedding_model(
     create: EmbeddingModelCreate,
 ) -> EmbeddingModelDetail:
     try:
-        return embedding_model_repo.create(session, create)
+        return embed_model_repo.create(session, create)
     except Exception as e:
         logger.exception(e)
         raise InternalServerError()
@@ -56,7 +56,7 @@ def test_embedding_model(
         expected_length = create.vector_dimension
         if len(embedding) != expected_length:
             raise ValueError(
-                f"Currently we only support {expected_length} dims embedding, got {len(embedding)} dims."
+                f"Embedding model is configured with {expected_length} dimensions, but got vector embedding with {len(embedding)} dimensions."
             )
         success = True
         error = ""
@@ -72,7 +72,7 @@ def list_embedding_models(
     user: CurrentSuperuserDep,
     params: Params = Depends()
 ) -> Page[EmbeddingModelItem]:
-    return embedding_model_repo.paginate(session, params)
+    return embed_model_repo.paginate(session, params)
 
 
 @router.get("/admin/embedding-models/{model_id}")
@@ -82,7 +82,7 @@ def get_embedding_model_detail(
     model_id: int
 ) -> EmbeddingModelDetail:
     try:
-        return embedding_model_repo.must_get(session, model_id)
+        return embed_model_repo.must_get(session, model_id)
     except EmbeddingModelNotFoundError as e:
         raise e
     except Exception as e:
@@ -98,8 +98,8 @@ def update_embedding_model(
     update: EmbeddingModelUpdate,
 ) -> EmbeddingModelDetail:
     try:
-        embed_model = embedding_model_repo.must_get(session, model_id)
-        embedding_model_repo.update(session, embed_model, update)
+        embed_model = embed_model_repo.must_get(session, model_id)
+        embed_model_repo.update(session, embed_model, update)
         return embed_model
     except EmbeddingModelNotFoundError as e:
         raise e
@@ -115,8 +115,8 @@ def set_default_embedding_model(
     model_id: int
 ) -> EmbeddingModelDetail:
     try:
-        embed_model = embedding_model_repo.must_get(session, model_id)
-        embedding_model_repo.set_default_model(session, model_id)
+        embed_model = embed_model_repo.must_get(session, model_id)
+        embed_model_repo.set_default_model(session, model_id)
         session.refresh(embed_model)
         return embed_model
     except EmbeddingModelNotFoundError as e:

--- a/backend/app/api/admin_routes/knowledge_base/data_sources/models.py
+++ b/backend/app/api/admin_routes/knowledge_base/data_sources/models.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel, field_validator
+
+from app.models import DataSourceType
+
+
+class KBDataSource(BaseModel):
+    """
+    Represents a linked data source for a knowledge base.
+    """
+    id: int
+    name: str
+    data_source_type: DataSourceType
+    config: dict | list
+
+
+class KBDataSourceMutable(BaseModel):
+    name: str
+
+    @field_validator("name")
+    def name_must_not_be_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Please provide a name for the data source")
+        return v
+
+
+class KBDataSourceCreate(KBDataSourceMutable):
+    data_source_type: DataSourceType
+    config: dict | list
+
+
+class KBDataSourceUpdate(KBDataSourceMutable):
+    pass

--- a/backend/app/api/admin_routes/knowledge_base/data_sources/routes.py
+++ b/backend/app/api/admin_routes/knowledge_base/data_sources/routes.py
@@ -1,0 +1,135 @@
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi_pagination import Params, Page
+
+from app.api.admin_routes.knowledge_base.data_sources.models import KBDataSourceUpdate, KBDataSource
+from app.api.admin_routes.knowledge_base.models import KBDataSourceCreate
+from app.api.deps import SessionDep, CurrentSuperuserDep
+from app.exceptions import (
+    InternalServerError,
+    KBDataSourceNotFoundError,
+    KnowledgeBaseNotFoundError
+)
+from app.models import DataSource
+from app.repositories import knowledge_base_repo
+from app.tasks.knowledge_base import (
+    import_documents_from_kb_datasource,
+    purge_kb_datasource_related_resources
+)
+
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.post("/admin/knowledge_bases/{kb_id}/datasources")
+def create_kb_datasource(
+    session: SessionDep,
+    user: CurrentSuperuserDep,
+    kb_id: int,
+    create: KBDataSourceCreate
+) -> KBDataSource:
+    try:
+        kb = knowledge_base_repo.must_get(session, kb_id)
+        new_data_source = DataSource(
+            name=create.name,
+            description="",
+            data_source_type=create.data_source_type,
+            config=create.config,
+        )
+        new_data_source = knowledge_base_repo.add_kb_datasource(session, kb, new_data_source)
+
+        import_documents_from_kb_datasource.delay(kb_id, new_data_source.id)
+
+        return new_data_source
+    except KnowledgeBaseNotFoundError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Failed to create data source for knowledge base #{kb_id}: {e}", exc_info=e)
+        raise InternalServerError()
+
+
+@router.put("/admin/knowledge_bases/{kb_id}/datasources/{data_source_id}")
+def update_kb_datasource(
+    session: SessionDep,
+    user: CurrentSuperuserDep,
+    kb_id: int,
+    data_source_id: int,
+    update: KBDataSourceUpdate,
+) -> KBDataSource:
+    try:
+        kb = knowledge_base_repo.must_get(session, kb_id)
+
+        data_source = kb.must_get_data_source_by_id(data_source_id)
+        data_source.name = update.name
+
+        session.add(data_source)
+        session.commit()
+        session.refresh(data_source)
+
+        return data_source
+    except KnowledgeBaseNotFoundError as e:
+        raise e
+    except KBDataSourceNotFoundError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Failed to update data source #{data_source_id}: {e}", exc_info=e)
+        raise InternalServerError()
+
+
+@router.get("/admin/knowledge_bases/{kb_id}/datasources/{data_source_id}")
+def get_kb_datasource(
+    session: SessionDep,
+    user: CurrentSuperuserDep,
+    kb_id: int,
+    data_source_id: int,
+) -> KBDataSource:
+    try:
+        kb = knowledge_base_repo.must_get(session, kb_id)
+        return kb.must_get_data_source_by_id(data_source_id)
+    except KnowledgeBaseNotFoundError as e:
+        raise e
+    except KBDataSourceNotFoundError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Failed to get data source #{data_source_id}: {e}", exc_info=e)
+        raise InternalServerError()
+
+
+@router.get("/admin/knowledge_bases/{kb_id}/datasources")
+def list_kb_datasources(
+    session: SessionDep,
+    user: CurrentSuperuserDep,
+    kb_id: int,
+    params: Params = Depends(),
+) -> Page[KBDataSource]:
+    return knowledge_base_repo.list_kb_datasources(session, kb_id, params)
+
+
+@router.delete("/admin/knowledge_bases/{kb_id}/datasources/{data_source_id}")
+def remove_kb_datasource(
+    session: SessionDep,
+    user: CurrentSuperuserDep,
+    kb_id: int,
+    data_source_id: int,
+):
+    try:
+        kb = knowledge_base_repo.must_get(session, kb_id)
+        data_source = kb.must_get_data_source_by_id(data_source_id)
+
+        # Flag the data source to be deleted, it will be deleted completely by the background job.
+        knowledge_base_repo.remove_kb_datasource(session, kb, data_source)
+
+        purge_kb_datasource_related_resources.delay(kb_id, data_source_id)
+
+        return {
+            "detail": "success"
+        }
+    except KnowledgeBaseNotFoundError as e:
+        raise e
+    except KBDataSourceNotFoundError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Failed to remove data source #{data_source_id} from knowledge base #{kb_id}: {e}", exc_info=e)
+        raise InternalServerError()

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -9,7 +9,8 @@ from app.api.routes import (
     feedback,
 )
 from app.api.admin_routes.knowledge_base.routes import router as admin_knowledge_base_router
-from app.api.admin_routes.knowledge_base.graph.routes import router as admin_knowledge_base_graph_router
+from app.api.admin_routes.knowledge_base.graph.routes import router as admin_kb_graph_router
+from app.api.admin_routes.knowledge_base.data_sources.routes import router as admin_kb_data_source_router
 from app.api.admin_routes.document.routes import router as admin_document_router
 from app.api.admin_routes.embedding_model.routes import router as admin_embedding_model_router
 from app.api.admin_routes import (
@@ -46,9 +47,9 @@ api_router.include_router(
 api_router.include_router(admin_upload.router, tags=["admin/upload"])
 api_router.include_router(admin_data_source.router, tags=["admin/data_source"])
 api_router.include_router(admin_knowledge_base_router, tags=["admin/knowledge_base"])
-api_router.include_router(admin_knowledge_base_graph_router, tags=["admin/knowledge_base/graph_editor"])
+api_router.include_router(admin_kb_graph_router, tags=["admin/knowledge_base/graph_editor"])
+api_router.include_router(admin_kb_data_source_router, tags=["admin/knowledge_base/data_source"])
 api_router.include_router(admin_llm.router, tags=["admin/llm"])
-
 api_router.include_router(admin_embedding_model_router, tags=["admin/embedding_model"])
 api_router.include_router(admin_retrieve.router, tags=["admin/retrieve"])
 api_router.include_router(admin_stats.router, tags=["admin/stats"])

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -36,13 +36,6 @@ class DefaultEmbeddingModelNotFoundError(HTTPException):
         self.detail = f"default embedding model is not found"
 
 
-class DataSourceNotFoundError(HTTPException):
-    status_code = 404
-
-    def __init__(self, data_source_id: int):
-        self.detail = f"data source #{data_source_id} is not found"
-
-
 class KnowledgeBaseNotFoundError(HTTPException):
     status_code = 404
 

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -18,8 +18,29 @@ class ChatNotFound(ChatException):
 class DBLLMNotFoundError(HTTPException):
     status_code = 404
 
-    def __init__(self, knowledge_base_id: int):
-        self.detail = f"llm #{knowledge_base_id} is not found"
+    def __init__(self, llm_id: int):
+        self.detail = f"llm #{llm_id} is not found"
+
+
+class DefaultLLMNotFoundError(HTTPException):
+    status_code = 404
+
+    def __init__(self):
+        self.detail = f"default llm is not found"
+
+
+class DefaultEmbeddingModelNotFoundError(HTTPException):
+    status_code = 404
+
+    def __init__(self):
+        self.detail = f"default embedding model is not found"
+
+
+class DataSourceNotFoundError(HTTPException):
+    status_code = 404
+
+    def __init__(self, data_source_id: int):
+        self.detail = f"data source #{data_source_id} is not found"
 
 
 class KnowledgeBaseNotFoundError(HTTPException):
@@ -27,6 +48,12 @@ class KnowledgeBaseNotFoundError(HTTPException):
 
     def __init__(self, knowledge_base_id: int):
         self.detail = f"knowledge base #{knowledge_base_id} is not found"
+
+class KBDataSourceNotFoundError(HTTPException):
+    status_code = 404
+
+    def __init__(self, kb_id: int, data_source_id: int):
+        self.detail = f"data source #{data_source_id} is not found in knowledge base #{kb_id}"
 
 class KBNoLLMConfiguredError(HTTPException):
     status_code = 500

--- a/backend/app/models/knowledge_base.py
+++ b/backend/app/models/knowledge_base.py
@@ -13,6 +13,7 @@ from sqlmodel import (
     SQLModel,
 )
 
+from app.exceptions import KBDataSourceNotFoundError
 from app.models.auth import User
 from app.models.data_source import DataSource
 from app.models.embed_model import EmbeddingModel
@@ -94,3 +95,12 @@ class KnowledgeBase(SQLModel, table=True):
 
     def __hash__(self):
         return hash(self.id)
+    
+    def get_data_source_by_id(self, data_source_id: int) -> Optional[DataSource]:
+        return next((ds for ds in self.data_sources if ds.id == data_source_id and not ds.deleted_at), None)
+    
+    def must_get_data_source_by_id(self, data_source_id: int) -> DataSource:
+        data_source = self.get_data_source_by_id(data_source_id)
+        if data_source is None:
+            raise KBDataSourceNotFoundError(self.id, data_source_id)
+        return data_source

--- a/backend/app/rag/build_index.py
+++ b/backend/app/rag/build_index.py
@@ -87,7 +87,7 @@ class IndexService:
 
         graph_store = get_kb_tidb_graph_store(session, self._knowledge_base)
         graph_index: KnowledgeGraphIndex = KnowledgeGraphIndex.from_existing(
-            dspy_lm=self._dspy_lm, kg_store=graph_store
+            dspy_lm=self._dspy_lm, kg_store=graph_store,
         )
 
         node = db_chunk.to_llama_text_node()

--- a/backend/app/rag/chat.py
+++ b/backend/app/rag/chat.py
@@ -50,6 +50,7 @@ from app.rag.chat_stream_protocol import (
     ChatEvent,
 )
 from app.models.relationship import get_kb_relationship_model
+from app.rag.knowledge_base.config import get_kb_embed_model
 from app.rag.knowledge_graph.graph_store import TiDBGraphStore
 from app.rag.vector_store.tidb_vector_store import TiDBVectorStore
 from app.rag.knowledge_graph.graph_store.tidb_graph_editor import legacy_tidb_graph_editor
@@ -75,15 +76,15 @@ class ChatService:
     _relationship_db_model: Type[SQLModel] = DBRelationship
 
     def __init__(
-            self,
-            *,
-            db_session: Session,
-            user: User,
-            browser_id: str,
-            origin: str,
-            chat_messages: List[ChatMessage],
-            engine_name: str = "default",
-            chat_id: Optional[UUID] = None,
+        self,
+        *,
+        db_session: Session,
+        user: User,
+        browser_id: str,
+        origin: str,
+        chat_messages: List[ChatMessage],
+        engine_name: str = "default",
+        chat_id: Optional[UUID] = None,
     ) -> None:
         self.db_session = db_session
         self.user = user
@@ -155,6 +156,7 @@ class ChatService:
             self._node_postprocessors = [self._metadata_filter]
             self._similarity_top_k = 10
 
+        # Langfuse
         self.langfuse_host = SiteSetting.langfuse_host
         self.langfuse_secret_key = SiteSetting.langfuse_secret_key
         self.langfuse_public_key = SiteSetting.langfuse_public_key
@@ -162,13 +164,16 @@ class ChatService:
             self.langfuse_host and self.langfuse_secret_key and self.langfuse_public_key
         )
 
+        # TODO: Support multiple knowledge base retrieve.
         if self.chat_engine_config.knowledge_base:
-            # TODO: Support multiple knowledge base retrieve.
             linked_knowledge_base = self.chat_engine_config.knowledge_base.linked_knowledge_base
             kb = knowledge_base_repo.must_get(db_session, linked_knowledge_base.id)
+            self._embed_model = get_kb_embed_model(db_session, kb)
             self._chunk_db_model = get_kb_chunk_model(kb)
             self._entity_db_model = get_kb_entity_model(kb)
             self._relationship_db_model = get_kb_relationship_model(kb)
+        else:
+            self._embed_model = get_default_embedding_model(db_session)
 
     def chat(self) -> Generator[ChatEvent | str, None, None]:
         try:
@@ -186,13 +191,13 @@ class ChatService:
             )
 
     def _search_kg(
-            self,
-            kg_config: KnowledgeGraphOption,
-            fast_dspy_lm: dspy.LM,
-            embed_model: BaseEmbedding,
-            get_llamaindex_callback_manager: Callable[[], Optional[CallbackManager]],
-            trace_url: str,
-            annotation_silent: bool = False,
+        self,
+        kg_config: KnowledgeGraphOption,
+        fast_dspy_lm: dspy.LM,
+        embed_model: BaseEmbedding,
+        get_llamaindex_callback_manager: Callable[[], Optional[CallbackManager]],
+        trace_url: str,
+        annotation_silent: bool = False,
     ) -> Generator[ChatEvent | str, None, Tuple[List[dict], List[dict], List[dict], dict, str]]:
         """
         Search the knowledge graph for relevant entities, relationships, and chunks.
@@ -306,12 +311,12 @@ class ChatService:
         return entities, relations, chunks, graph_data_source_ids, graph_knowledges_context
 
     def _get_llamaindex_callback_manager(
-            self,
-            langfuse: Optional[Langfuse] = None,
-            trace_id: Optional[str] = None,
-            llm: Optional[LLM] = None,
-            fast_llm: Optional[LLM] = None,
-            embed_model: Optional[BaseEmbedding] = None,
+        self,
+        langfuse: Optional[Langfuse] = None,
+        trace_id: Optional[str] = None,
+        llm: Optional[LLM] = None,
+        fast_llm: Optional[LLM] = None,
+        embed_model: Optional[BaseEmbedding] = None,
     ) -> CallbackManager:
         # Why we don't use high-level decorator `observe()` as \
         #   `https://langfuse.com/docs/integrations/llama-index/get-started` suggested?
@@ -371,12 +376,12 @@ class ChatService:
         clarifying_question: str
 
     def _refine_or_early_stop(
-            self,
-            get_llamaindex_callback_manager: Callable[[], Optional[CallbackManager]],
-            fast_llm: LLM,
-            graph_knowledges_context: str,
-            refined_question_prompt: Optional[str] = None,
-            annotation_silent: bool = False,
+        self,
+        get_llamaindex_callback_manager: Callable[[], Optional[CallbackManager]],
+        fast_llm: LLM,
+        graph_knowledges_context: str,
+        refined_question_prompt: Optional[str] = None,
+        annotation_silent: bool = False,
     ) -> Generator[ChatEvent | str, None, Tuple[bool, str, str]]:
         """
         Determine whether to refine the user question or early stop the conversation with a clarifying question.
@@ -471,13 +476,13 @@ class ChatService:
         return False, "", refined_question
 
     def _gen_answer_via_llama_index(
-            self,
-            get_llamaindex_callback_manager: Callable[[], Optional[CallbackManager]],
-            refined_question: str,
-            graph_knowledges_context: str,
-            llm: LLM,
-            embed_model: BaseEmbedding,
-            annotation_silent: bool = False,
+        self,
+        get_llamaindex_callback_manager: Callable[[], Optional[CallbackManager]],
+        refined_question: str,
+        graph_knowledges_context: str,
+        llm: LLM,
+        embed_model: BaseEmbedding,
+        annotation_silent: bool = False,
     ) -> Generator[ChatEvent | str, None, Tuple[StreamingResponse, List[dict]]]:
         if not annotation_silent:
             yield ChatEvent(
@@ -545,13 +550,13 @@ class ChatService:
         return response, source_documents
 
     def _chat_finish(
-            self,
-            db_assistant_message: ChatMessage,
-            db_user_message: ChatMessage,
-            response_text: str,
-            source_documents: List[dict],
-            graph_data_source_ids: dict,
-            annotation_silent: bool = False,
+        self,
+        db_assistant_message: ChatMessage,
+        db_user_message: ChatMessage,
+        response_text: str,
+        source_documents: List[dict],
+        graph_data_source_ids: dict,
+        annotation_silent: bool = False,
     ):
         if not annotation_silent:
             yield ChatEvent(
@@ -612,7 +617,7 @@ class ChatService:
             ),
         )
 
-        _embed_model = get_default_embedding_model(self.db_session)
+        # TODO: remove to __init__?
         _llm = self.chat_engine_config.get_llama_llm(self.db_session)
         _fast_llm = self.chat_engine_config.get_fast_llama_llm(self.db_session)
         _fast_dspy_lm = self.chat_engine_config.get_fast_dspy_lm(self.db_session)
@@ -632,7 +637,7 @@ class ChatService:
                 trace_id=trace_id,
                 llm=_llm,
                 fast_llm=_fast_llm,
-                embed_model=_embed_model,
+                embed_model=self._embed_model,
             )
 
         # 1. Retrieve entities, relations, and chunks from the knowledge graph
@@ -640,7 +645,7 @@ class ChatService:
         entities, relations, chunks, graph_data_source_ids, graph_knowledges_context = yield from self._search_kg(
             kg_config=kg_config,
             fast_dspy_lm=_fast_dspy_lm,
-            embed_model=_embed_model,
+            embed_model=self._embed_model,
             trace_url=trace_url,
             get_llamaindex_callback_manager=_get_llamaindex_callback_manager_in_chat,
         )
@@ -665,7 +670,7 @@ class ChatService:
                 refined_question=refined_question,
                 graph_knowledges_context=graph_knowledges_context,
                 llm=_llm,
-                embed_model=_embed_model,
+                embed_model=self._embed_model,
             )
 
             response_text = ""
@@ -717,27 +722,13 @@ class ChatService:
             ),
         )
 
-        _embed_model = get_default_embedding_model(self.db_session)
+        # TODO: remove to __init__?
         _fast_dspy_lm = self.chat_engine_config.get_fast_dspy_lm(self.db_session)
         _fast_llm = self.chat_engine_config.get_fast_llama_llm(self.db_session)
 
         # retrieve entities, relations, and chunks from the knowledge graph
         # this retrieve progress is only for the clarifying question checking
         try:
-            """
-            kg_config = self.chat_engine_config.knowledge_graph
-            _, _, _, graph_data_source_ids, graph_knowledges_context = yield from self._search_kg(
-                kg_config=kg_config,
-                fast_dspy_lm=_fast_dspy_lm,
-                embed_model=_embed_model,
-                trace_url="",
-                get_llamaindex_callback_manager=lambda: self._get_llamaindex_callback_manager(
-                    fast_llm=_fast_llm,
-                    embed_model=_embed_model,
-                ),
-                annotation_silent=True,
-            )
-            """
             graph_data_source_ids = []
             graph_knowledges_context = ""
 
@@ -745,7 +736,7 @@ class ChatService:
             early_stop, clarifying_question, goal = yield from self._refine_or_early_stop(
                 get_llamaindex_callback_manager=lambda: self._get_llamaindex_callback_manager(
                     fast_llm=_fast_llm,
-                    embed_model=_embed_model,
+                    embed_model=self._embed_model,
                 ),
                 fast_llm=_fast_llm,
                 graph_knowledges_context=graph_knowledges_context,
@@ -808,31 +799,6 @@ class ChatService:
             except Exception as e:
                 logger.error(f"Failed to get task_id from chunk: {e}")
 
-        """
-        try:
-            response_text = ""
-            final_answer_gen = _fast_llm.stream(
-                get_prompt_by_jinja2_template(
-                    self.chat_engine_config.llm.condense_answer_prompt,
-                    chat_history=self.chat_history,
-                    question=self.user_question,
-                    agent_answer=stackvm_response_text,
-                )
-            )
-            for word in final_answer_gen:
-                response_text += word
-                yield ChatEvent(
-                    event_type=ChatEventType.TEXT_PART,
-                    payload=word,
-                )
-        except Exception as e:
-            for word in stackvm_response_text:
-                yield ChatEvent(
-                    event_type=ChatEventType.TEXT_PART,
-                    payload=word,
-                )
-            logger.error(f"Failed to refine question: {e}")
-        """
         response_text = stackvm_response_text
         base_url = stream_chat_api_url.replace('/api/stream_execute_vm', '')
         db_assistant_message.content = response_text
@@ -1029,8 +995,9 @@ def get_graph_data_from_langfuse(trace_url: str):
 def get_chat_message_subgraph(
     session: Session,
     chat_message: DBChatMessage,
+    embed_model: BaseEmbedding,
     entity_db_model: SQLModel = DBEntity,
-    relationship_db_model: SQLModel = DBRelationship
+    relationship_db_model: SQLModel = DBRelationship,
 ) -> Tuple[List, List]:
     if chat_message.role != MessageRole.USER:
         return [], []
@@ -1087,7 +1054,7 @@ def get_chat_message_subgraph(
     graph_store = TiDBGraphStore(
         dspy_lm=chat_engine_config.get_fast_dspy_lm(session),
         session=session,
-        embed_model=get_default_embedding_model(session),
+        embed_model=embed_model,
         entity_db_model=entity_db_model,
         relationship_db_model=relationship_db_model,
     )

--- a/backend/app/rag/chat_config.py
+++ b/backend/app/rag/chat_config.py
@@ -30,9 +30,9 @@ from app.rag.node_postprocessor.metadata_post_filter import MetadataFilters
 from app.rag.node_postprocessor.baisheng_reranker import BaishengRerank
 from app.rag.node_postprocessor.local_reranker import LocalRerank
 from app.rag.embeddings.local_embedding import LocalEmbedding
-from app.repositories import chat_engine_repo
-from app.repositories.embedding_model import embedding_model_repo
-from app.repositories.llm import get_default_db_llm
+from app.repositories import chat_engine_repo, knowledge_base_repo
+from app.repositories.embedding_model import embed_model_repo
+from app.repositories.llm import llm_repo
 from app.types import LLMProvider, EmbeddingProvider, RerankerProvider
 from app.rag.default_prompt import (
     DEFAULT_INTENT_GRAPH_KNOWLEDGE,
@@ -256,9 +256,7 @@ def get_llm(
 
 
 def get_default_llm(session: Session) -> LLM:
-    db_llm = get_default_db_llm(session)
-    if not db_llm:
-        raise ValueError("No default LLM found in DB")
+    db_llm = llm_repo.must_get_default_llm(session)
     return get_llm(
         db_llm.provider,
         db_llm.model,
@@ -316,9 +314,7 @@ def get_embedding_model(
 
 
 def get_default_embedding_model(session: Session) -> BaseEmbedding:
-    db_embed_model = embedding_model_repo.get_default_model(session)
-    if not db_embed_model:
-        raise ValueError("No default embedding model found in DB")
+    db_embed_model = embed_model_repo.must_get_default_model(session)
     return get_embedding_model(
         db_embed_model.provider,
         db_embed_model.model,

--- a/backend/app/rag/knowledge_base/index_store.py
+++ b/backend/app/rag/knowledge_base/index_store.py
@@ -50,7 +50,7 @@ def init_kb_tidb_graph_store(session: Session, kb: KnowledgeBase) -> TiDBGraphSt
 
 
 def get_kb_tidb_graph_editor(session: Session, kb: KnowledgeBase) -> TiDBGraphEditor:
-    entity_model = get_kb_entity_model(kb)
-    relationship_model = get_kb_relationship_model(kb)
-    init_kb_tidb_vector_store(session, kb)
-    return TiDBGraphEditor(entity_model, relationship_model)
+    entity_db_model = get_kb_entity_model(kb)
+    relationship_db_model = get_kb_relationship_model(kb)
+    embed_model = get_kb_embed_model(session, kb)
+    return TiDBGraphEditor(entity_db_model, relationship_db_model, embed_model)

--- a/backend/app/rag/knowledge_graph/graph_store/tidb_graph_editor.py
+++ b/backend/app/rag/knowledge_graph/graph_store/tidb_graph_editor.py
@@ -37,8 +37,8 @@ class TiDBGraphEditor:
             self._embed_model = resolve_embed_model(embed_model)
         else:
             self._embed_model = OpenAIEmbedding(
-            model=OpenAIEmbeddingModelType.TEXT_EMBED_3_SMALL
-        )
+                model=OpenAIEmbeddingModelType.TEXT_EMBED_3_SMALL
+            )
 
 
     def get_entity(self, session: Session, entity_id: int) -> Optional[SQLModel]:

--- a/backend/app/rag/knowledge_graph/graph_store/tidb_graph_editor.py
+++ b/backend/app/rag/knowledge_graph/graph_store/tidb_graph_editor.py
@@ -1,5 +1,8 @@
 from typing import Optional, Tuple, List, Type
 
+from llama_index.core.embeddings import resolve_embed_model
+from llama_index.core.embeddings.utils import EmbedType
+from llama_index.embeddings.openai import OpenAIEmbedding, OpenAIEmbeddingModelType
 from sqlmodel import Session, select, SQLModel
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.attributes import flag_modified
@@ -14,7 +17,6 @@ from app.rag.knowledge_graph.graph_store.helpers import (
 
 from app.rag.knowledge_graph.graph_store.tidb_graph_store import TiDBGraphStore
 from app.rag.knowledge_graph.schema import Relationship as RelationshipAIModel
-from app.rag.chat_config import get_default_embedding_model
 from app.staff_action import create_staff_action_log
 
 
@@ -22,10 +24,21 @@ class TiDBGraphEditor:
     _entity_db_model: Type[SQLModel]
     _relationship_db_model: Type[SQLModel]
 
+    def __init__(
+        self,
+        entity_db_model: Type[SQLModel],
+        relationship_db_model: Type[SQLModel],
+        embed_model: Optional[EmbedType] = None,
+    ):
+        self._entity_db_model = entity_db_model
+        self._relationship_db_model = relationship_db_model
 
-    def __init__(self, entity_model: Type[SQLModel], relationship_model: Type[SQLModel]):
-        self._entity_db_model = entity_model
-        self._relationship_db_model = relationship_model
+        if embed_model:
+            self._embed_model = resolve_embed_model(embed_model)
+        else:
+            self._embed_model = OpenAIEmbedding(
+            model=OpenAIEmbeddingModelType.TEXT_EMBED_3_SMALL
+        )
 
 
     def get_entity(self, session: Session, entity_id: int) -> Optional[SQLModel]:
@@ -38,11 +51,10 @@ class TiDBGraphEditor:
             if value is not None:
                 setattr(entity, key, value)
                 flag_modified(entity, key)
-        embed_model = get_default_embedding_model(session)
         entity.description_vec = get_entity_description_embedding(
-            entity.name, entity.description, embed_model
+            entity.name, entity.description, self._embed_model
         )
-        entity.meta_vec = get_entity_metadata_embedding(entity.meta, embed_model)
+        entity.meta_vec = get_entity_metadata_embedding(entity.meta, self._embed_model)
         for relationship in session.exec(
             select(self._relationship_db_model)
             .options(
@@ -60,7 +72,7 @@ class TiDBGraphEditor:
                 relationship.target_entity.name,
                 relationship.target_entity.description,
                 relationship.description,
-                embed_model,
+                self._embed_model,
             )
             session.add(relationship)
         session.commit()
@@ -137,14 +149,13 @@ class TiDBGraphEditor:
             if value is not None:
                 setattr(relationship, key, value)
                 flag_modified(relationship, key)
-        embed_model = get_default_embedding_model(session)
         relationship.description_vec = get_relationship_description_embedding(
             relationship.source_entity.name,
             relationship.source_entity.description,
             relationship.target_entity.name,
             relationship.target_entity.description,
             relationship.description,
-            embed_model,
+            self._embed_model,
         )
         session.commit()
         session.refresh(relationship)
@@ -162,8 +173,7 @@ class TiDBGraphEditor:
 
 
     def search_similar_entities(self, session: Session, query: str, top_k: int = 10) -> list:
-        embed_model = get_default_embedding_model(session)
-        embedding = get_query_embedding(query, embed_model)
+        embedding = get_query_embedding(query, self._embed_model)
         return session.exec(
             select(self._entity_db_model)
             .where(self._entity_db_model.entity_type == EntityType.original)
@@ -181,16 +191,15 @@ class TiDBGraphEditor:
         meta: dict,
         related_entities_ids: List[int],
     ) -> SQLModel:
-        embed_model = get_default_embedding_model(session)
         # with session.begin():
         synopsis_entity = self._entity_db_model(
             name=name,
             description=description,
             description_vec=get_entity_description_embedding(
-                name, description, embed_model
+                name, description, self._embed_model
             ),
             meta=meta,
-            meta_vec=get_entity_metadata_embedding(meta, embed_model),
+            meta_vec=get_entity_metadata_embedding(meta, self._embed_model),
             entity_type=EntityType.synopsis,
             synopsis_info={
                 "entities": related_entities_ids,
@@ -201,7 +210,7 @@ class TiDBGraphEditor:
         graph_store = TiDBGraphStore(
             dspy_lm=None,
             session=session,
-            embed_model=embed_model,
+            embed_model=self._embed_model,
             entity_db_model=self._entity_db_model,
             relationship_db_model=self._relationship_db_model
         )

--- a/backend/app/rag/retrieve.py
+++ b/backend/app/rag/retrieve.py
@@ -17,6 +17,7 @@ from app.rag.chat import get_prompt_by_jinja2_template
 from app.rag.chat_config import ChatEngineConfig, get_default_embedding_model
 from app.models.relationship import get_kb_relationship_model
 from app.models.patch.sql_model import SQLModel
+from app.rag.knowledge_base.config import get_kb_embed_model
 from app.rag.knowledge_graph import KnowledgeGraphIndex
 from app.rag.knowledge_graph.graph_store import TiDBGraphStore
 from app.rag.vector_store.tidb_vector_store import TiDBVectorStore
@@ -50,6 +51,10 @@ class RetrieveService:
             self._chunk_model = get_kb_chunk_model(kb)
             self._entity_model = get_kb_entity_model(kb)
             self._relationship_model = get_kb_relationship_model(kb)
+            self._embed_model = get_kb_embed_model(self.db_session, kb)
+        else:
+            self._embed_model = get_default_embedding_model(self.db_session)
+
 
     def retrieve(self, question: str, top_k: int = 10) -> List[DBDocument]:
         """
@@ -68,7 +73,7 @@ class RetrieveService:
             logger.exception(e)
 
     def _retrieve(self, question: str, top_k: int) -> List[DBDocument]:
-        _embed_model = get_default_embedding_model(self.db_session)
+        # TODO: move to __init__?
         _llm = self.chat_engine_config.get_llama_llm(self.db_session)
         _fast_llm = self.chat_engine_config.get_fast_llama_llm(self.db_session)
         _fast_dspy_lm = self.chat_engine_config.get_fast_dspy_lm(self.db_session)
@@ -79,7 +84,7 @@ class RetrieveService:
             graph_store = TiDBGraphStore(
                 dspy_lm=_fast_dspy_lm,
                 session=self.db_session,
-                embed_model=_embed_model,
+                embed_model=self._embed_model,
                 entity_db_model=self._entity_model,
                 relationship_db_model=self._relationship_model,
             )
@@ -141,7 +146,7 @@ class RetrieveService:
         vector_store = TiDBVectorStore(session=self.db_session, chunk_db_model=self._chunk_model)
         vector_index = VectorStoreIndex.from_vector_store(
             vector_store,
-            embed_model=_embed_model,
+            embed_model=self._embed_model,
         )
 
         retrieve_engine = vector_index.as_retriever(
@@ -158,12 +163,10 @@ class RetrieveService:
         return source_documents
 
     def _embedding_retrieve(self, question: str, top_k: int) -> List[NodeWithScore]:
-        _embed_model = get_default_embedding_model(self.db_session)
-
         vector_store = TiDBVectorStore(session=self.db_session, chunk_db_model=self._chunk_model)
         vector_index = VectorStoreIndex.from_vector_store(
             vector_store,
-            embed_model=_embed_model
+            embed_model=self._embed_model
         )
 
         retrieve_engine = vector_index.as_retriever(

--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -1,13 +1,14 @@
 from typing import Optional, Type
 from datetime import datetime, UTC
 
+from sqlalchemy import delete
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select, Session, func, update
 from fastapi_pagination import Params, Page
 from fastapi_pagination.ext.sqlmodel import paginate
 
 from app.api.admin_routes.knowledge_base.models import VectorIndexError, KGIndexError, KnowledgeBaseUpdate
-from app.exceptions import KnowledgeBaseNotFoundError
+from app.exceptions import KBDataSourceNotFoundError, KnowledgeBaseNotFoundError
 from app.models import (
     KnowledgeBase,
     Document,
@@ -15,6 +16,7 @@ from app.models import (
     KgIndexStatus, Chunk, KnowledgeBaseDataSource,
 )
 from app.models.chunk import get_kb_chunk_model
+from app.models.data_source import DataSource
 from app.models.entity import get_kb_entity_model
 from app.models.knowledge_base import IndexMethod
 from app.models.relationship import get_kb_relationship_model
@@ -35,16 +37,16 @@ class KnowledgeBaseRepo(BaseRepo):
         )
         return paginate(session, query, params)
 
-    def get(self, session: Session, knowledge_base_id: int, include_soft_deleted: bool = True) -> Optional[KnowledgeBase]:
+    def get(self, session: Session, knowledge_base_id: int, show_soft_deleted: bool = True) -> Optional[KnowledgeBase]:
         stmt = select(KnowledgeBase).where(KnowledgeBase.id == knowledge_base_id)
 
-        if not include_soft_deleted:
+        if not show_soft_deleted:
             stmt = stmt.where(KnowledgeBase.deleted_at == None)
 
         return session.exec(stmt).first()
     
-    def must_get(self, session: Session, knowledge_base_id: int) -> Optional[KnowledgeBase]:
-        kb = self.get(session, knowledge_base_id)
+    def must_get(self, session: Session, knowledge_base_id: int, show_soft_deleted: bool = True) -> Optional[KnowledgeBase]:
+        kb = self.get(session, knowledge_base_id, show_soft_deleted)
         if kb is None:
             raise KnowledgeBaseNotFoundError(knowledge_base_id)
         return kb
@@ -195,7 +197,6 @@ class KnowledgeBaseRepo(BaseRepo):
 
         return chunk_ids
 
-
     def list_vector_index_built_errors(
         self,
         session: Session,
@@ -226,7 +227,6 @@ class KnowledgeBaseRepo(BaseRepo):
                 for row in rows
             ]
         )
-
 
     def list_kg_index_built_errors(
         self,
@@ -263,6 +263,64 @@ class KnowledgeBaseRepo(BaseRepo):
             for row in rows
         ])
 
+    def get_kb_datasource(
+        self,
+        session: Session,
+        kb: KnowledgeBase,
+        datasource_id: int,
+        show_soft_deleted: bool = False
+    ) -> DataSource:
+        stmt = select(DataSource).where(DataSource.id == datasource_id)
+        if not show_soft_deleted:
+            stmt = stmt.where(DataSource.deleted_at == None)
+        return session.exec(stmt).first()
+    
+    def must_get_kb_datasource(
+        self,
+        session: Session,
+        kb: KnowledgeBase,
+        datasource_id: int,
+        show_soft_deleted: bool = False
+    ) -> DataSource:
+        data_source = self.get_kb_datasource(session, kb, datasource_id, show_soft_deleted)
+        if data_source is None:
+            raise KBDataSourceNotFoundError(kb.id, datasource_id)
+        return data_source
+
+    def add_kb_datasource(self, session: Session, kb: KnowledgeBase, data_source: DataSource) -> DataSource:
+        session.add(data_source)
+        kb.data_sources.append(data_source)
+        
+        session.add(kb)
+        session.commit()
+        session.refresh(data_source)
+        
+        return data_source
+
+    def list_kb_datasources(self, session: Session, kb_id: int, params: Params | None = Params()) -> Page[DataSource]:
+        query = (
+            select(DataSource)
+            .join(KnowledgeBaseDataSource)
+            .where(
+                DataSource.deleted_at == None,
+                KnowledgeBaseDataSource.knowledge_base_id == kb_id
+            )
+            .order_by(DataSource.created_at.desc())
+        )
+        return paginate(session, query, params)
+
+    def remove_kb_datasource(self, session: Session, kb: KnowledgeBase, data_source: DataSource) -> None:
+        # Flag the data source to be deleted.
+        data_source.deleted_at = datetime.now(UTC)
+        session.add(data_source)
+
+        # Remove the data source from the knowledge base.
+        stmt = delete(KnowledgeBaseDataSource).where(
+            KnowledgeBaseDataSource.knowledge_base_id == kb.id,
+            KnowledgeBaseDataSource.data_source_id == data_source.id
+        )
+        session.exec(stmt)
+        session.commit()
 
 
 knowledge_base_repo = KnowledgeBaseRepo()

--- a/backend/app/repositories/llm.py
+++ b/backend/app/repositories/llm.py
@@ -2,23 +2,35 @@ from typing import Type
 
 from sqlmodel import select, Session
 
-from app.exceptions import DBLLMNotFoundError
+from app.exceptions import DefaultLLMNotFoundError
 from app.models import (
     LLM as DBLLM
 )
 
 
-def get_db_llm(session: Session, llm_id: int) -> Type[DBLLM] | None:
-    return session.get(DBLLM, llm_id)
+class LLMRepo:
+    model_cls: DBLLM
+
+    def get_db_llm(self, session: Session, llm_id: int) -> Type[DBLLM] | None:
+        return session.get(DBLLM, llm_id)
 
 
-def must_get_llm(session: Session, llm_id: int) -> Type[DBLLM]:
-    db_llm = get_db_llm(session, llm_id)
-    if db_llm is None:
-        raise DBLLMNotFoundError(llm_id)
-    return db_llm
+    def must_get_llm(self, session: Session, llm_id: int) -> Type[DBLLM]:
+        db_llm = self.get_db_llm(session, llm_id)
+        if db_llm is None:
+            raise DefaultLLMNotFoundError(llm_id)
+        return db_llm
 
 
-def get_default_db_llm(session: Session) -> Type[DBLLM] | None:
-    stmt = select(DBLLM).where(DBLLM.is_default == True).order_by(DBLLM.updated_at.desc()).limit(1)
-    return session.exec(stmt).first()
+    def get_default_llm(self, session: Session) -> Type[DBLLM] | None:
+        stmt = select(DBLLM).where(DBLLM.is_default == True).order_by(DBLLM.updated_at.desc()).limit(1)
+        return session.exec(stmt).first()
+
+
+    def must_get_default_llm(self, session: Session) -> Type[DBLLM]:
+        db_llm = self.get_default_llm(session)
+        if db_llm is None:
+            raise DefaultLLMNotFoundError()
+        return db_llm
+
+llm_repo = LLMRepo()

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -8,7 +8,7 @@ from .rag_build import (
 )
 from .knowledge_base import (
     import_documents_for_knowledge_base,
-    purge_knowledge_base_related_resources,
+    purge_kb_datasource_related_resources,
 )
 from .build_index import (
     build_index_for_document,
@@ -22,7 +22,7 @@ __all__ = [
     "build_vector_index_from_document",
     "build_kg_index_from_chunk",
     "import_documents_for_knowledge_base",
-    "purge_knowledge_base_related_resources",
+    "purge_kb_datasource_related_resources",
     "import_documents_from_datasource",
     "purge_datasource_related_resources",
 ]

--- a/backend/app/tasks/knowledge_base.py
+++ b/backend/app/tasks/knowledge_base.py
@@ -1,6 +1,6 @@
 from celery.utils.log import get_task_logger
 from sqlalchemy import delete
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.celery import app as celery_app
 from app.core.db import engine
@@ -10,8 +10,11 @@ from app.models import (
 )
 from app.models.knowledge_base import KnowledgeBase
 from app.rag.datasource import get_data_source_loader
-from app.repositories import knowledge_base_repo
+from app.repositories import knowledge_base_repo, data_source_repo
 from .build_index import build_index_for_document
+from ..models.chunk import get_kb_chunk_model
+from ..models.entity import get_kb_entity_model
+from ..models.relationship import get_kb_relationship_model
 from ..rag.knowledge_base.index_store import get_kb_tidb_vector_store, get_kb_tidb_graph_store
 
 logger = get_task_logger(__name__)
@@ -23,24 +26,41 @@ def import_documents_for_knowledge_base(knowledge_base_id: int):
             kb = knowledge_base_repo.must_get(session, knowledge_base_id)
             data_sources = kb.data_sources
             for data_source in data_sources:
-                loader = get_data_source_loader(
-                    session,
-                    knowledge_base_id,
-                    data_source.data_source_type,
-                    data_source.id,
-                    data_source.user_id,
-                    data_source.config,
-                )
-                for document in loader.load_documents():
-                    session.add(document)
-                    session.commit()
-
-                    build_index_for_document.delay(kb.id, document.id)
+                import_documents_from_kb_datasource(kb.id, data_source.id)
         logger.info(f"Successfully imported documents for knowledge base #{knowledge_base_id}")
     except KnowledgeBaseNotFoundError:
         logger.error(f"Knowledge base #{knowledge_base_id} is not found")
     except Exception as e:
         logger.exception(f"Failed to import documents for knowledge base #{knowledge_base_id}", exc_info=e)
+
+
+@celery_app.task
+def import_documents_from_kb_datasource(kb_id: int, data_source_id: int):
+    try:
+        with Session(engine) as session:
+            kb = knowledge_base_repo.must_get(session, kb_id)
+            data_source = knowledge_base_repo.must_get_kb_datasource(session, kb, data_source_id)
+
+            logger.info(f"Loading documents from data source #{data_source_id} for knowledge base #{kb_id}")
+            loader = get_data_source_loader(
+                session,
+                kb_id,
+                data_source.data_source_type,
+                data_source.id,
+                data_source.user_id,
+                data_source.config,
+            )
+
+            for document in loader.load_documents():
+                session.add(document)
+                session.commit()
+
+                build_index_for_document.delay(kb_id, document.id)
+    except Exception as e:
+        logger.exception(
+            f"Failed to import documents from data source #{data_source_id} of knowledge base #{kb_id}",
+            exc_info=e
+        )
 
 
 @celery_app.task
@@ -67,7 +87,8 @@ def stats_for_knowledge_base(knowledge_base_id: int):
 
 @celery_app.task
 def purge_knowledge_base_related_resources(knowledge_base_id: int):
-    """Purge all resources related to a knowledge base.
+    """
+    Purge all resources related to a knowledge base.
 
     Related resources:
         - documents
@@ -79,11 +100,7 @@ def purge_knowledge_base_related_resources(knowledge_base_id: int):
     """
 
     with Session(engine) as session:
-        knowledge_base = knowledge_base_repo.get(session, knowledge_base_id, include_soft_deleted=True)
-        if knowledge_base is None:
-            logger.error(f"Knowledge base with id {knowledge_base_id} not found")
-            return
-
+        knowledge_base = knowledge_base_repo.must_get(session, knowledge_base_id, show_soft_deleted=True)
         assert knowledge_base.deleted_at is not None
 
         data_source_ids = [datasource.id for datasource in knowledge_base.data_sources]
@@ -104,19 +121,76 @@ def purge_knowledge_base_related_resources(knowledge_base_id: int):
         session.exec(stmt)
         logger.info(f"Deleted documents of knowledge base #{knowledge_base_id} successfully.")
 
-        # Delete data source links.
-        stmt = delete(KnowledgeBaseDataSource).where(KnowledgeBase.id == knowledge_base_id)
-        session.exec(stmt)
-        logger.info(f"Deleted linked data sources of knowledge base #{knowledge_base_id} successfully.")
+        # Delete data sources and links.
+        if len(data_source_ids) > 0:
+            stmt = delete(KnowledgeBaseDataSource).where(KnowledgeBase.id == knowledge_base_id)
+            session.exec(stmt)
+            logger.info(f"Deleted linked data sources of knowledge base #{knowledge_base_id} successfully.")
 
-        # Delete data sources.
-        stmt = delete(DataSource).where(DataSource.id.in_(data_source_ids))
-        session.exec(stmt)
-        logger.info(f"Deleted data sources {', '.join([f'#{did}' for did in data_source_ids])} successfully.")
+            stmt = delete(DataSource).where(DataSource.id.in_(data_source_ids))
+            session.exec(stmt)
+            logger.info(f"Deleted data sources {', '.join([f'#{did}' for did in data_source_ids])} successfully.")
 
         # Delete knowledge base.
         stmt = delete(KnowledgeBase).where(KnowledgeBase.id == knowledge_base_id)
         session.exec(stmt)
         logger.info(f"Deleted knowledge base #{knowledge_base_id} successfully.")
+
+        session.commit()
+
+
+@celery_app.task
+def purge_kb_datasource_related_resources(kb_id: int, datasource_id: int):
+    """
+    Purge all resources related to the deleted datasource in the knowledge base.
+    """
+
+    with Session(engine) as session:
+        kb = knowledge_base_repo.must_get(session, kb_id, show_soft_deleted=True)
+        datasource = knowledge_base_repo.must_get_kb_datasource(session, kb, datasource_id, show_soft_deleted=True)
+        assert datasource.deleted_at is not None
+
+        chunk_model = get_kb_chunk_model(kb)
+        entity_model = get_kb_entity_model(kb)
+        relationship_model = get_kb_relationship_model(kb)
+
+        doc_ids_subquery = select(Document.id).where(Document.data_source_id == datasource_id)
+        chunk_ids_subquery = select(chunk_model.id).where(chunk_model.document_id.in_(doc_ids_subquery))
+
+        # Delete relationships generated by the chunks of the deleted data source.
+        stmt = delete(relationship_model).where(relationship_model.chunk_id.in_(chunk_ids_subquery))
+        session.exec(stmt)
+        logger.info(f"Deleted relationships generated by chunks from data source #{datasource_id} successfully.")
+
+        # Delete orphaned entities that are not referenced by any relationships.
+        orphaned_entity_ids = (
+            select(entity_model.id)
+                .outerjoin(
+                    relationship_model,
+                    (relationship_model.target_entity_id == entity_model.id) |
+                    (relationship_model.source_entity_id == entity_model.id)
+                )
+                .where(
+                    relationship_model.id.is_(None)
+                )
+                .scalar_subquery()
+        )
+        stmt = delete(entity_model).where(entity_model.id.in_(orphaned_entity_ids))
+        session.exec(stmt)
+        logger.info(f"Deleted orphaned entities successfully.")
+
+        # Delete chunks from deleted data source.
+        stmt = delete(chunk_model).where(chunk_model.document_id.in_(doc_ids_subquery))
+        session.exec(stmt)
+        logger.info(f"Deleted chunks from data source #{datasource_id} successfully.")
+
+        # Delete documents.
+        stmt = delete(Document).where(Document.data_source_id == datasource_id)
+        session.exec(stmt)
+        logger.info(f"Deleted documents from data source #{datasource_id} successfully.")
+
+        # Delete data sources.
+        session.delete(datasource)
+        logger.info(f"Deleted data source #{datasource_id} successfully.")
 
         session.commit()


### PR DESCRIPTION
Add KB datasource management API:

- `GET: /admin/knowledge_bases/{kb_id}/datasources`
- `POST: /admin/knowledge_bases/{kb_id}/datasources/{datasource_id}`
- `PUT:  /admin/knowledge_bases/{kb_id}/datasources/{datasource_id}`
- `DELETE: /admin/knowledge_bases/{kb_id}/datasources/{datasource_id}`

The data sources will be the exclusive resources at the knowledge base level. **The old datasource management API will be deprecated.**
