### PR TITLE
fix bug: docker container process will crash when upload a big PDF(100M).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local-embedding-reranker
 
 *.swp
 *.swo
+*.log

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -71,3 +71,20 @@ class Document(UpdatableBaseModel, table=True):
             text=self.content,
             metadata=self.meta,
         )
+    def to_llama_with_new_content(self, new_content: str) -> LlamaDocument:
+        return LlamaDocument(
+            id_=str(self.id),
+            text=new_content,
+            metadata=self.meta,
+        )
+    def truncate_content(self, max_length: int) -> str:
+        # sometimes we don't need to store the full content in the database
+        content_length = len(self.content)
+        if content_length > max_length:
+            original_content = self.content
+            self.content = self.content[:max_length] + "..."
+            return original_content
+        return None
+
+    def get_content_length(self) -> int:
+        return len(self.content)

--- a/backend/app/rag/build_index.py
+++ b/backend/app/rag/build_index.py
@@ -36,7 +36,7 @@ class IndexService:
         self._embed_model = embed_model
         self._knowledge_base = knowledge_base
 
-    def build_vector_index_for_document(self, session: Session, db_document: Type[DBDocument]):
+    def build_vector_index_for_document(self, session: Session, db_document: Type[DBDocument], original_content: str=None):
         """
         Build vector index and graph index from document.
 
@@ -67,7 +67,11 @@ class IndexService:
             transformations=_transformations
         )
 
-        document = db_document.to_llama_document()
+        # document = db_document.to_llama_document()
+        if (original_content is not None):
+            document = db_document.to_llama_with_new_content(original_content)
+        else:
+            document = db_document.to_llama_document()
         logger.info(f"Start building vector index for document #{document.doc_id}.")
         vector_index.insert(document, source_uri=db_document.source_uri)
         logger.info(f"Finish building vector index for document #{document.doc_id}.")

--- a/backend/app/tasks/build_index.py
+++ b/backend/app/tasks/build_index.py
@@ -23,7 +23,7 @@ logger = get_task_logger(__name__)
 # TODO: refactor: divide into two tasks: build_vector_index_for_document and build_kg_index_for_document
 
 @celery_app.task(bind=True)
-def build_index_for_document(self, knowledge_base_id: int, document_id: int):
+def build_index_for_document(self, knowledge_base_id: int, document_id: int, original_content: str=None):
     # Pre-check before building index.
     with Session(engine, expire_on_commit=False) as session:
         kb = knowledge_base_repo.must_get(session, knowledge_base_id)
@@ -57,7 +57,7 @@ def build_index_for_document(self, knowledge_base_id: int, document_id: int):
     # Build vector index.
     try:
         with Session(engine) as index_session:
-            index_service.build_vector_index_for_document(index_session, db_document)
+            index_service.build_vector_index_for_document(index_session, db_document, original_content)
 
         with Session(engine) as session:
             db_document.index_status = DocIndexTaskStatus.COMPLETED


### PR DESCRIPTION
The bug originated from Tidb's limitation on the length of the TEXT field to 6MB. When inserting document data into the db, the SQL execution failed due to the content being too long, exceeding 6MB. For this situation, consider truncating the content to meet the length limit and retaining the original content for indexing construction, so as not to affect the execution of subsequent processes. 
