### PR TITLE
fix: structured prediction is only for openai api

### DIFF
--- a/backend/app/rag/chat.py
+++ b/backend/app/rag/chat.py
@@ -448,21 +448,23 @@ class ChatService:
                         MyCBEventType.CLARIFYING_QUESTION,
                         payload={EventPayload.QUERY_STR: refined_question},
                 ) as event:
-                    clarity_result = fast_llm.structured_predict(
-                        output_cls=self.ClarityResult,
+                    clarity_result = fast_llm.predict(
                         prompt=get_prompt_by_jinja2_template(
                             self.chat_engine_config.llm.clarifying_question_prompt,
                             graph_knowledges=graph_knowledges_context,
                             chat_history=self.chat_history,
                             question=refined_question,
                         ),
-                    )
+                    ).strip().strip(".\"\'!")
+
+                    clarity_needed = clarity_result.lower() != "false"
+
                     event.on_end(payload={
-                        EventPayload.COMPLETION: f"Need Clarification: {clarity_result.clarity_needed}, "
-                                                 f"Clarifying Question: {clarity_result.clarifying_question}"
+                        EventPayload.COMPLETION: f"Need Clarification: {clarity_needed}, "
+                                                 f"Clarifying Question: {clarity_result}"
                     })
 
-                    if clarity_result.clarity_needed:
+                    if clarity_needed:
                         if not annotation_silent:
                             yield ChatEvent(
                                 event_type=ChatEventType.MESSAGE_ANNOTATIONS_PART,
@@ -474,10 +476,10 @@ class ChatService:
 
                         yield ChatEvent(
                             event_type=ChatEventType.TEXT_PART,
-                            payload=clarity_result.clarifying_question,
+                            payload=clarity_result,
                         )
 
-                        return True, clarity_result.clarifying_question, ""
+                        return True, clarity_result, ""
 
         return False, "", refined_question
 
@@ -1167,10 +1169,6 @@ def check_rag_config_need_migration(session: Session) -> NeedMigrationStatus:
         chat_engines_without_kb_configured=chat_engines_without_kb_configured,
     )
 
-class LLMRecommendQuestions(BaseModel):
-    """recommend questions respond model"""
-    questions: List[str]
-
 
 def remove_chat_message_recommend_questions(
     db_session: Session,
@@ -1199,29 +1197,28 @@ def get_chat_message_recommend_questions(
     if questions is not None:
         return questions
 
-    recommend_questions = llm.structured_predict(
-        output_cls=LLMRecommendQuestions,
+    recommend_questions = llm.predict(
         prompt=get_prompt_by_jinja2_template(
             chat_engine_config.llm.further_questions_prompt,
             chat_message_content=chat_message.content,
         ),
     )
+    recommend_question_list = recommend_questions.splitlines()
+    recommend_question_list = [question.strip() for question in recommend_question_list if question.strip()]
 
     longest_question = 0
-    for question in recommend_questions.questions:
+    for question in recommend_question_list:
         longest_question = max(longest_question, len(question))
 
     # check the output by if the output with format and the length
-    questions = ",".join(recommend_questions.questions)
-    if "##" in questions or "**" in questions or longest_question > 500:
+    if "##" in recommend_questions or "**" in recommend_questions or longest_question > 500:
         regenerate_content = f"""
         Please note that you are generating a question list. You previously generated it incorrectly; try again.
         ----------------------------------------
         {chat_message.content}
         """
         # with format or too long for per question, it's not a question list, generate again
-        recommend_questions = llm.structured_predict(
-            output_cls=LLMRecommendQuestions,
+        recommend_questions = llm.predict(
             prompt=get_prompt_by_jinja2_template(
                 chat_engine_config.llm.further_questions_prompt,
                 chat_message_content=regenerate_content,
@@ -1230,8 +1227,8 @@ def get_chat_message_recommend_questions(
 
     db_session.add(RecommendQuestion(
         chat_message_id=chat_message.id,
-        questions=recommend_questions.questions,
+        questions=recommend_question_list,
     ))
     db_session.commit()
 
-    return recommend_questions.questions
+    return recommend_question_list

--- a/backend/app/rag/default_prompt.py
+++ b/backend/app/rag/default_prompt.py
@@ -73,8 +73,8 @@ Instructions:
    - If the user's question is too vague or lacks key information, identify what additional information would be necessary for clarity.
 
 2. Generate a Clarifying Question:
-   - If the question is clear and answerable, return "False" and leave the clarifying question empty ("").
-   - If clarification is needed, return "True" and generate a specific question to ask the user, directly addressing the information gap. Avoid general questions; focus on the specific details required for an accurate answer.
+   - If the question is clear and answerable, return exact "False" as the response.
+   - If clarification is needed, return a specific question to ask the user, directly addressing the information gap. Avoid general questions; focus on the specific details required for an accurate answer.
 
 3. Use the same language to ask the clarifying question as the user's original question.
 
@@ -85,8 +85,7 @@ Relevant Knowledge: TiDB supports foreign keys starting from version 6.6.0.
 
 Response:
 
-- Clarity Needed: True
-- Clarifying Question: "Which version of TiDB are you using?"
+Which version of TiDB are you using?
 
 Example 2:
 
@@ -95,8 +94,16 @@ Relevant Knowledge: TiDB supports nested transaction starting from version 6.2.0
 
 Response:
 
-- Clarity Needed: True
-- Clarifying Question: "Which version of TiDB are you using?"
+Which version of TiDB are you using?
+
+Example 3:
+
+user: "Does TiDB support foreign keys? I'm using TiDB 6.5.0."
+Relevant Knowledge: TiDB supports foreign keys starting from version 6.6.0.
+
+Response:
+
+False
 
 Your Turn:
 
@@ -288,6 +295,7 @@ Instructions:
 4. Keep questions concise yet insightful to maximize engagement.
 5. Use the same language with the chat message content.
 6. Each question should end with a question mark.
+7. Each question should be in a new line, DO NOT add any indexes or blank lines, just output the questions.
 
 Now, generate 3–5 follow-up questions below:
 """


### PR DESCRIPTION
The `structured_predict` leverages a specific tool that only exists in the OpenAI API. Drop it off.