### PR TITLE
docs: fix dev docker compose filepath on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Setting up the project on your local machine is the first step to contributing t
 To test your local changes, you can build and run the project using:
 
 ```bash
-docker compose -f docker-compose.build.yml up
+docker compose -f docker-compose.dev.yml up
 ```
 
 ### Your First Contribution


### PR DESCRIPTION
`docker-compose.build.yml` does not exist.

![image](https://github.com/user-attachments/assets/4c83afd3-3fd6-48b1-81ea-d2cbed368426)
