### PR TITLE
add response format requirements

### DIFF
--- a/backend/app/rag/knowledge_graph/extractor.py
+++ b/backend/app/rag/knowledge_graph/extractor.py
@@ -46,6 +46,7 @@ class ExtractGraphTriplet(dspy.Signature):
 
     Objective: Produce a detailed and comprehensive knowledge graph that captures the full spectrum of entities mentioned in the text, along with their interrelations, reflecting both broad concepts and intricate details specific to the database domain.
 
+    Please only response in JSON format.
     """
 
     text = dspy.InputField(
@@ -62,6 +63,8 @@ class ExtractCovariate(dspy.Signature):
     Ensure all extracted covariates is clearly connected to the correct entity for accuracy and comprehensive understanding.
     Ensure that all extracted covariates are factual and verifiable within the text itself, without relying on external knowledge or assumptions.
     Collectively, the covariates should provide a thorough and precise summary of the entity's characteristics as described in the source material.
+
+    Please only response in JSON format.
     """
 
     text = dspy.InputField(

--- a/backend/app/rag/knowledge_graph/graph_store/tidb_graph_store.py
+++ b/backend/app/rag/knowledge_graph/graph_store/tidb_graph_store.py
@@ -49,6 +49,7 @@ class MergeEntities(dspy.Signature):
     If the entities are distinct despite their same name that may be due to different contexts or perspectives, do not merge the entities and return none as the merged entity.
 
     Considerations: Ensure your decision is based on a comprehensive analysis of the content and context provided within the entity descriptions and metadata.
+    Please only response in JSON Format.
     """
 
     entities: List[Entity] = dspy.InputField(
@@ -394,9 +395,13 @@ class TiDBGraphStore(KnowledgeGraphStore):
 
     def _try_merge_entities(self, entities: List[Entity]) -> Entity:
         logger.info(f"Trying to merge entities: {entities[0].name}")
-        with dspy.settings.context(lm=self._dspy_lm):
-            pred = self.merge_entities_prog(entities=entities)
-            return pred.merged_entity
+        try:
+            with dspy.settings.context(lm=self._dspy_lm):
+                pred = self.merge_entities_prog(entities=entities)
+                return pred.merged_entity
+        except Exception as e:
+            logger.error(f"Failed to merge entities: {e}", exc_info=True)
+            return None
 
     def retrieve_with_weight(
         self,

--- a/backend/app/rag/knowledge_graph/intent.py
+++ b/backend/app/rag/knowledge_graph/intent.py
@@ -46,6 +46,8 @@ class DecomposeQuery(dspy.Signature):
         - Limit the output to no more than 5 questions to maintain focus and relevance.
         - Ensure accuracy by reflecting the user's true intentions based on the provided query.
         - Ground all questions in factual information derived directly from the user's input.
+
+    Please only response in JSON format.
     """
 
     query: str = dspy.InputField(

--- a/backend/app/rag/knowledge_graph/prerequisite.py
+++ b/backend/app/rag/knowledge_graph/prerequisite.py
@@ -30,6 +30,8 @@ class DecomposePrerequisites(dspy.Signature):
     - Ensure that the prerequisite questions are directly relevant and necessary for answering the main query.
     - Do not include unnecessary or unrelated questions.
     - Ensure that the questions are grounded and factual, based on the query provided.
+
+    Please only response in JSON format.
     """
 
     query: str = dspy.InputField(


### PR DESCRIPTION
Because most of the dspy programs we are using are uncompiled versions, it is easy to have unexpected behavior, so add an explicit requirement to increase the stability of the output