### PR TITLE
feat: support relationship_meta_filters / similarity_top_k /  oversampling_factor for retrieve api

### DIFF
--- a/backend/app/api/admin_routes/knowledge_base/graph/models.py
+++ b/backend/app/api/admin_routes/knowledge_base/graph/models.py
@@ -33,6 +33,7 @@ class GraphSearchRequest(BaseModel):
     include_meta: bool = True
     depth: int = 2
     with_degree: bool = True
+    relationship_meta_filters: dict = {}
 
 
 class KnowledgeRequest(BaseModel):

--- a/backend/app/api/admin_routes/knowledge_base/graph/routes.py
+++ b/backend/app/api/admin_routes/knowledge_base/graph/routes.py
@@ -207,7 +207,7 @@ def search_graph(session: SessionDep, kb_id: int, request: GraphSearchRequest):
             request.include_meta,
             request.with_degree,
             False,
-            {},
+            request.relationship_meta_filters,
         )
         return {
             "entities": entities,

--- a/backend/app/api/admin_routes/models.py
+++ b/backend/app/api/admin_routes/models.py
@@ -42,3 +42,5 @@ class RetrieveRequest(BaseModel):
     query: str
     chat_engine: Optional[str] = "default"
     top_k: Optional[int] = 5
+    similarity_top_k: Optional[int] = None
+    oversampling_factor: Optional[int] = 5

--- a/backend/app/api/admin_routes/retrieve.py
+++ b/backend/app/api/admin_routes/retrieve.py
@@ -17,9 +17,16 @@ async def retrieve_documents(
     question: str,
     chat_engine: str = "default",
     top_k: Optional[int] = 5,
+    similarity_top_k: Optional[int] = None,
+    oversampling_factor: Optional[int] = 5,
 ) -> List[Document]:
     retrieve_service = RetrieveService(session, chat_engine)
-    return retrieve_service.retrieve(question, top_k=top_k)
+    return retrieve_service.retrieve(
+        question,
+        top_k=top_k,
+        similarity_top_k=similarity_top_k,
+        oversampling_factor=oversampling_factor,
+    )
 
 
 @router.get("/admin/embedding_retrieve")
@@ -29,9 +36,16 @@ async def embedding_retrieve(
     question: str,
     chat_engine: str = "default",
     top_k: Optional[int] = 5,
+    similarity_top_k: Optional[int] = None,
+    oversampling_factor: Optional[int] = 5,
 ) -> List[NodeWithScore]:
     retrieve_service = RetrieveService(session, chat_engine)
-    return retrieve_service._embedding_retrieve(question, top_k=top_k)
+    return retrieve_service._embedding_retrieve(
+        question,
+        top_k=top_k,
+        similarity_top_k=similarity_top_k,
+        oversampling_factor=oversampling_factor,
+    )
 
 
 @router.post("/admin/embedding_retrieve")
@@ -41,4 +55,9 @@ async def embedding_search(
     request: RetrieveRequest,
 ) -> List[NodeWithScore]:
     retrieve_service = RetrieveService(session, request.chat_engine)
-    return retrieve_service._embedding_retrieve(request.query, top_k=request.top_k)
+    return retrieve_service._embedding_retrieve(
+        request.query,
+        top_k=request.top_k,
+        similarity_top_k=request.similarity_top_k,
+        oversampling_factor=request.oversampling_factor,
+    )

--- a/backend/app/rag/vector_store/tidb_vector_store.py
+++ b/backend/app/rag/vector_store/tidb_vector_store.py
@@ -55,8 +55,13 @@ class TiDBVectorStore(BasePydanticVectorStore):
         self,
         session: Optional[Session] = None,
         chunk_db_model: SQLModel = Chunk,
+        oversampling_factor: int = 5,
         **kwargs: Any,
     ) -> None:
+        """
+        Args:
+            oversampling_factor (int): The oversampling factor for the similarity search. The higher the factor, the higher recall rate.
+        """
         super().__init__(**kwargs)
         self._session = session
         self._owns_session = session is None
@@ -64,6 +69,7 @@ class TiDBVectorStore(BasePydanticVectorStore):
             self._session = Session(engine)
 
         self._chunk_db_model = chunk_db_model
+        self._oversampling_factor = oversampling_factor
 
     def ensure_table_schema(self) -> None:
         inspector = sqlalchemy.inspect(engine)
@@ -179,7 +185,7 @@ class TiDBVectorStore(BasePydanticVectorStore):
         if query.query_embedding is None:
             raise ValueError("Query embedding must be provided.")
 
-        stmt = select(
+        subquery = select(
             self._chunk_db_model.id,
             self._chunk_db_model.text,
             self._chunk_db_model.meta,
@@ -190,9 +196,14 @@ class TiDBVectorStore(BasePydanticVectorStore):
 
         if query.filters:
             for f in query.filters.filters:
-                stmt = stmt.where(self._chunk_db_model.meta[f.key] == f.value)
+                subquery = subquery.where(self._chunk_db_model.meta[f.key] == f.value)
 
-        stmt = stmt.order_by(asc("distance")).limit(query.similarity_top_k)
+        subquery = (
+            subquery.order_by(asc("distance"))
+            .limit(query.similarity_top_k * self._oversampling_factor)
+            .subquery("sub")
+        )
+        stmt = select(subquery).order_by(asc("distance")).limit(query.similarity_top_k)
         results = self._session.exec(stmt)
 
         nodes = []


### PR DESCRIPTION
close #570

For  `/admin/knowledge_bases/{kb_id}/graph/search` API, , add parameter:

- `relationship_meta_filters`: pass the filtering conditions.

For `/admin/retrieve/documents` API, add two parameters:
- `similarity_top_k` to control how many nodes should the vector search return, if not set, using the value of `top_k` by default.
- `oversampling_factor`: This is similar to the `ef_search` parameter of the HNSW index, the larger the parameter, the higher the recall rate. Since TiDB does not yet support modifying the value of `ef_search`, the current implementation uses subquery. The subquery returns the `similarity_top_k * oversampling_factor` rows, and the outer query finally returns the `similarity_top_k` rows.
- At this time, if you need to turn on `metadata_filter`, you need to modify the Chat Engine configuration, this problem will be fixed after the retrieve API refactor (#573), thr new retrieve API will not dependant on the ChatEngine configuration.
