### PR TITLE
fix: avoid OpenAILikeEmbedding always use zhipu api url when knowledge graph building

### DIFF
--- a/backend/app/rag/chat_config.py
+++ b/backend/app/rag/chat_config.py
@@ -5,7 +5,6 @@ from typing import Dict, Optional
 import dspy
 from llama_index.llms.bedrock.utils import BEDROCK_FOUNDATION_LLMS
 from pydantic import BaseModel
-from llama_index.llms.openai.utils import DEFAULT_OPENAI_API_BASE
 from llama_index.llms.openai import OpenAI
 from llama_index.llms.openai_like import OpenAILike
 from llama_index.llms.gemini import Gemini
@@ -219,10 +218,8 @@ def get_llm(
 ) -> LLM:
     match provider:
         case LLMProvider.OPENAI:
-            api_base = config.pop("api_base", DEFAULT_OPENAI_API_BASE)
             return OpenAI(
                 model=model,
-                api_base=api_base,
                 api_key=credentials,
                 **config,
             )
@@ -247,6 +244,7 @@ def get_llm(
                 aws_secret_access_key=secret_access_key,
                 region_name=region_name,
                 context_size=context_size,
+                **config,
             )
             # Note: Because llama index Bedrock class doesn't set up these values to the corresponding
             # attributes in its constructor function, we pass the values again via setter to pass them to
@@ -315,10 +313,8 @@ def get_embed_model(
 ) -> BaseEmbedding:
     match provider:
         case EmbeddingProvider.OPENAI:
-            api_base = config.pop("api_base", DEFAULT_OPENAI_API_BASE)
             return OpenAIEmbedding(
                 model=model,
-                api_base=api_base,
                 api_key=credentials,
                 **config,
             )
@@ -332,6 +328,7 @@ def get_embed_model(
             return CohereEmbedding(
                 model_name=model,
                 cohere_api_key=credentials,
+                **config,
             )
         case EmbeddingProvider.BEDROCK:
             return BedrockEmbedding(
@@ -359,10 +356,8 @@ def get_embed_model(
                 **config,
             )
         case EmbeddingProvider.OPENAI_LIKE:
-            api_base = config.pop("api_base", "https://open.bigmodel.cn/api/paas/v4")
             return OpenAILikeEmbedding(
                 model=model,
-                api_base=api_base,
                 api_key=credentials,
                 **config,
             )
@@ -408,12 +403,14 @@ def get_reranker_model(
                 model=model,
                 top_n=top_n,
                 api_key=credentials,
+                **config,
             )
         case RerankerProvider.COHERE:
             return CohereRerank(
                 model=model,
                 top_n=top_n,
                 api_key=credentials,
+                **config,
             )
         case RerankerProvider.BAISHENG:
             return BaishengRerank(


### PR DESCRIPTION
When using `OpenAILikeEmbedding`, if a provider other than zhipu is configured, the bug of the authentication information error will appear when building knowledge graph.

```
[2025-01-08 03:10:38,501: INFO/ForkPoolWorker-2] HTTP Request: POST https://open.bigmodel.cn/api/paas/v4/embeddings "HTTP/1.1 401 Unauthorized"
[2025-01-08 03:10:38,507: ERROR/ForkPoolWorker-2] app.tasks.build_index.build_kg_index_for_chunk[4489bfc3-0e7c-4606-ad77-b973ef24a3f1]: Failed to build knowledge graph index for chunk #60564d4d-1522-476c-9660-ab1859ee2b1e
Traceback (most recent call last):
  File "/app/app/tasks/build_index.py", line 125, in build_kg_index_for_chunk
    index_service.build_kg_index_for_chunk(index_session, db_chunk)
```

This bug is due to `config.pop()`call will remove the `api_base` param from the config.

In the method of `get_embed_model` / `get_llm` / `get_reranker_model`, the config should be inmutable.

