### PR TITLE
fix(celery): set name for celery worker

### DIFF
--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 logfile=/var/log/supervisord.log
 
 [program:celery_worker]
-command=celery -A app.celery worker -Q default --concurrency=5 --loglevel=INFO --logfile=/var/log/celery_worker.log
+command=celery -A app.celery worker -n worker-default@%%h -Q default --concurrency=5 --loglevel=INFO --logfile=/var/log/celery_worker.log
 directory=/app
 stdout_logfile=/var/log/celery_worker_supervisor.log
 stdout_logfile_maxbytes=52428800
@@ -11,7 +11,7 @@ redirect_stderr=true
 autorestart=true
 
 [program:evaluation_worker]
-command=celery -A app.celery worker -Q evaluation --pool=solo --loglevel=INFO --logfile=/var/log/evaluation_worker.log
+command=celery -A app.celery worker -n worker-evaluation@%%h -Q evaluation --pool=solo --loglevel=INFO --logfile=/var/log/evaluation_worker.log
 directory=/app
 stdout_logfile=/var/log/evaluation_worker_supervisor.log
 stdout_logfile_maxbytes=52428800


### PR DESCRIPTION
Set name for celery worker so that it can be display correct in flower dashboard.

![image](https://github.com/user-attachments/assets/45b49417-015e-4e52-a3d2-56b9acf44593)
