### PR TITLE
fix(docs): fix wrong parameter name in example of ollama_embeddings

### DIFF
--- a/frontend/app/src/pages/docs/embedding-model.mdx
+++ b/frontend/app/src/pages/docs/embedding-model.mdx
@@ -152,7 +152,7 @@ To use Ollama, you'll need to configure the API base URL in the **Advanced Setti
 
 ```json
 {
-    "api_base": "http://localhost:11434"
+    "base_url": "http://localhost:11434"
 }
 ```
 


### PR DESCRIPTION
Close #609.