### PR TITLE
fix: remove langfuse_url trace annotation

### DIFF
--- a/backend/app/rag/chat.py
+++ b/backend/app/rag/chat.py
@@ -515,13 +515,6 @@ class ChatFlow:
                 assistant_message=db_assistant_message,
             ),
         )
-        yield ChatEvent(
-            event_type=ChatEventType.MESSAGE_ANNOTATIONS_PART,
-            payload=ChatStreamMessagePayload(
-                state=ChatMessageSate.TRACE,
-                context={"langfuse_url": self.trace_url},
-            ),
-        )
         return db_user_message, db_assistant_message
 
     def _search_knowledge_graph(


### PR DESCRIPTION
Frontend can get the trace url from db_message, so we don't need to return via another event.