### PR TITLE
feat(frontend): support multiple knowledge base for network graph viewer

### DIFF
--- a/frontend/app/src/api/chats.ts
+++ b/frontend/app/src/api/chats.ts
@@ -1,5 +1,5 @@
 import type { ChatEngineOptions } from '@/api/chat-engines';
-import { type KnowledgeGraph, knowledgeGraphSchema } from '@/api/graph';
+import { type KnowledgeGraph, KnowledgeGraphEntityType, knowledgeGraphSchema } from '@/api/graph';
 import { bufferedReadableStreamTransformer } from '@/lib/buffered-readable-stream';
 import { authenticationHeaders, handleErrors, handleResponse, type Page, type PageParams, requestUrl, zodPage } from '@/lib/request';
 import { zodJsonDate } from '@/lib/zod';

--- a/frontend/app/src/api/graph.ts
+++ b/frontend/app/src/api/graph.ts
@@ -14,6 +14,7 @@ export const enum KnowledgeGraphEntityType {
 
 export interface KnowledgeGraphEntity {
   id: number;
+  knowledge_base_id?: number | null;
   name: string;
   description: string;
   meta: object;
@@ -28,6 +29,7 @@ export interface KnowledgeGraphRelationship {
   id: number;
   source_entity_id: number;
   target_entity_id: number;
+  knowledge_base_id?: number | null;
   description: string;
   meta: object;
   weight: number;
@@ -35,6 +37,7 @@ export interface KnowledgeGraphRelationship {
 
 export const entitySchema = z.object({
   id: z.number(),
+  knowledge_base_id: z.number().nullable().optional(),
   name: z.string(),
   description: z.string(),
   meta: z.object({}).passthrough(),
@@ -47,6 +50,7 @@ export const entitySchema = z.object({
 
 export const relationshipSchema = z.object({
   id: z.number(),
+  knowledge_base_id: z.number().nullable().optional(),
   source_entity_id: z.number(),
   target_entity_id: z.number(),
   description: z.string(),

--- a/frontend/app/src/components/chat/knowledge-graph-debug-info.tsx
+++ b/frontend/app/src/components/chat/knowledge-graph-debug-info.tsx
@@ -5,6 +5,8 @@ import type { OngoingState } from '@/components/chat/chat-message-controller';
 import { AppChatStreamState, type StackVMState } from '@/components/chat/chat-stream-state';
 import { NetworkViewer } from '@/components/graph/components/NetworkViewer';
 import { useNetwork } from '@/components/graph/useNetwork';
+import { PencilIcon } from 'lucide-react';
+import Link from 'next/link';
 import { useEffect } from 'react';
 import useSWR from 'swr';
 
@@ -12,7 +14,7 @@ export function KnowledgeGraphDebugInfo ({ group }: { group: ChatMessageGroup })
   const { engine_options } = useChatInfo(useCurrentChatController()) ?? {};
   const auth = useAuth();
   const ongoing = useChatMessageStreamState(group.assistant);
-  const kbLinked = !!engine_options?.knowledge_base?.linked_knowledge_bases?.length;
+  const kbLinked = engine_options?.knowledge_base?.linked_knowledge_bases;
   const canEdit = !!auth.me?.is_superuser && kbLinked;
 
   const shouldFetch = (!ongoing || ongoing.finished || couldFetchKnowledgeGraphDebugInfo(ongoing));
@@ -41,15 +43,49 @@ export function KnowledgeGraphDebugInfo ({ group }: { group: ChatMessageGroup })
       loadingTitle={shouldFetch ? 'Loading knowledge graph...' : 'Waiting knowledge graph request...'}
       network={network}
       Details={
-        () => null
-        //// TODO: Don't know which KB subgraph to edit for now.
-        // () => canEdit
-        //   ? (
-        //     <Link href={`/knowledge-bases/${kbLinked}/knowledge-graph-explorer?query=${encodeURIComponent(`message-subgraph:${group.user.id}`)}`} className="absolute top-2 right-2 text-xs underline">
-        //       <PencilIcon className="w-3 h-3 mr-1 inline-block" />
-        //       Edit graph
-        //     </Link>
-        //   ) : null
+        ({ target, network }) => {
+          if (!canEdit) return null;
+
+          if (!kbLinked) return null;
+
+          if (kbLinked.length === 1) {
+            return (
+              <Link href={`/knowledge-bases/${kbLinked}/knowledge-graph-explorer?query=${encodeURIComponent(`message-subgraph:${group.user.id}`)}`} className="absolute top-2 right-2 text-xs underline">
+                <PencilIcon className="w-3 h-3 mr-1 inline-block" />
+                Edit graph
+              </Link>
+            );
+          }
+
+          const placeholder = <span className="text-muted-foreground absolute top-2 right-2 text-xs underline cursor-not-allowed">
+            <PencilIcon className="w-3 h-3 mr-1 inline-block" />
+            Edit graph
+          </span>;
+
+          if (!target) return placeholder;
+
+          if (target.type === 'node') {
+            const node = network.node(target.id);
+            if (!node?.knowledge_base_id) return placeholder;
+            return (
+              <Link href={`/knowledge-bases/${node.knowledge_base_id}/knowledge-graph-explorer?query=${encodeURIComponent(`message-subgraph:${group.user.id}`)}`} className="absolute top-2 right-2 text-xs underline">
+                <PencilIcon className="w-3 h-3 mr-1 inline-block" />
+                Edit graph
+              </Link>
+            );
+          } else if (target.type === 'link') {
+            const link = network.node(target.id);
+            if (!link?.knowledge_base_id) return placeholder;
+            return (
+              <Link href={`/knowledge-bases/${link.knowledge_base_id}/knowledge-graph-explorer?query=${encodeURIComponent(`message-subgraph:${group.user.id}`)}`} className="absolute top-2 right-2 text-xs underline">
+                <PencilIcon className="w-3 h-3 mr-1 inline-block" />
+                Edit graph
+              </Link>
+            );
+          }
+
+          return placeholder;
+        }
       }
     />
   );

--- a/frontend/app/src/components/graph/components/NodeDetails.tsx
+++ b/frontend/app/src/components/graph/components/NodeDetails.tsx
@@ -3,10 +3,10 @@ import { Loader } from '@/components/loader';
 import { toastError, toastSuccess } from '@/lib/ui-error';
 import { cn } from '@/lib/utils';
 import { useContext, useEffect, useMemo, useState } from 'react';
-import type { Entity } from '../utils';
 import type { IdType } from '../network/Network';
 import { useRemote } from '../remote';
 import { useDirtyEntity } from '../useDirtyEntity';
+import { type Entity, handleServerEntity } from '../utils';
 import { EditingButton } from './EditingButton';
 import { InputField } from './InputField';
 import { JsonField } from './JsonField';
@@ -33,7 +33,7 @@ export function NodeDetails ({
     return Array.from(network.nodeNeighborhoods(entity.id) ?? []).map(id => network.node(id)!);
   }, [network, entity.id]);
 
-  const latestData = useRemote(entity, getEntity, knowledgeBaseId, Number(entity.id));
+  const latestData = useRemote(entity, (kb, id) => getEntity(kb, id).then(handleServerEntity), knowledgeBaseId, Number(entity.id));
   const dirtyEntity = useDirtyEntity(knowledgeBaseId, entity.id);
 
   // dirty set
@@ -75,7 +75,7 @@ export function NodeDetails ({
       </div>
       {entity.synopsis_info?.topic && <section>
         <h6 className="text-xs font-bold text-accent-foreground mb-1">Synopsis topic</h6>
-        <p className='block w-full text-xs text-accent-foreground'>
+        <p className="block w-full text-xs text-accent-foreground">
           {entity.synopsis_info.topic}
         </p>
       </section>}

--- a/frontend/app/src/components/graph/components/NodeDetails.tsx
+++ b/frontend/app/src/components/graph/components/NodeDetails.tsx
@@ -13,6 +13,8 @@ import { JsonField } from './JsonField';
 import { NetworkContext } from './NetworkContext';
 import { TextareaField } from './TextareaField';
 
+const loadEntity = (kbId: number, id: number) => getEntity(kbId, id).then(handleServerEntity);
+
 export function NodeDetails ({
   knowledgeBaseId,
   entity,
@@ -33,7 +35,7 @@ export function NodeDetails ({
     return Array.from(network.nodeNeighborhoods(entity.id) ?? []).map(id => network.node(id)!);
   }, [network, entity.id]);
 
-  const latestData = useRemote(entity, (kb, id) => getEntity(kb, id).then(handleServerEntity), knowledgeBaseId, Number(entity.id));
+  const latestData = useRemote(entity, loadEntity, knowledgeBaseId, Number(entity.id));
   const dirtyEntity = useDirtyEntity(knowledgeBaseId, entity.id);
 
   // dirty set

--- a/frontend/app/src/components/graph/network/NetworkRenderer.ts
+++ b/frontend/app/src/components/graph/network/NetworkRenderer.ts
@@ -6,6 +6,8 @@ export interface NetworkRendererOptions<Node, Link> {
   showId?: boolean;
   showLinkLabel?: boolean;
 
+  getNodeInitialAttrs?: (node: Node, index: number) => Pick<SimulationNodeDatum, 'x' | 'y'>;
+
   getNodeLabel?: (node: Node) => string | undefined;
   getNodeDetails?: (node: Node) => string | undefined;
   getNodeMeta?: (node: Node) => any;
@@ -95,6 +97,8 @@ export class NetworkRenderer<Node extends NetworkNode, Link extends NetworkLink>
         label: options.getNodeLabel?.(node),
         details: options.getNodeDetails?.(node),
         meta: options.getNodeMeta?.(node),
+        // x, y
+        ...options.getNodeInitialAttrs?.(node, index),
       };
     });
     this.links = this.network.links().map((link, index) => ({

--- a/frontend/app/src/components/graph/utils.ts
+++ b/frontend/app/src/components/graph/utils.ts
@@ -2,6 +2,8 @@ import { type KnowledgeGraph, type KnowledgeGraphEntity, type KnowledgeGraphRela
 
 export type Entity = {
   id: number | string
+  knowledge_base_id?: number | null;
+  node_id: number;
   name: string
   description: string
   meta: any
@@ -16,6 +18,8 @@ export type Entity = {
 
 export type Relationship = {
   id: number | string
+  knowledge_base_id?: number | null;
+  relationship_id: number;
   source: number | string
   target: number | string
   meta: any
@@ -32,14 +36,20 @@ export type GraphData = {
 }
 
 export function handleServerEntity (serverEntity: KnowledgeGraphEntity): Entity {
-  return serverEntity;
+  return {
+    ...serverEntity,
+    id: `${serverEntity.knowledge_base_id ?? 0}-${serverEntity.id}`,
+    node_id: serverEntity.id,
+  };
 }
 
 export function handleServerRelationship ({ source_entity_id, target_entity_id, ...rest }: KnowledgeGraphRelationship): Relationship {
   return ({
     ...rest,
-    source: source_entity_id,
-    target: target_entity_id,
+    id: `${rest.knowledge_base_id ?? 0}-${rest.id}`,
+    relationship_id: rest.id,
+    source: `${rest.knowledge_base_id ?? 0}-${source_entity_id}`,
+    target: `${rest.knowledge_base_id ?? 0}-${target_entity_id}`,
   });
 }
 


### PR DESCRIPTION
close #618

- if results contains only one knowledge base, use primary color as before (black in light mode, white in dark mode)
- if results contains more than one knowledge bases, use chart colors from --var-chart-{i} (maximum 5 colors supported currently.)
- nodes are clustered by given initial positions related by knowledge base index. See [source code](https://github.com/pingcap/autoflow/pull/632/files#diff-8d3ac41ab813aa1c75973f9179b00263a639951e5882b21be8cfaa52aee46213R24) for more details.
